### PR TITLE
fix: split `browser` and `node` entries

### DIFF
--- a/js/format.ts
+++ b/js/format.ts
@@ -1,36 +1,11 @@
 import './wasm_exec.js';
 
-interface FormatOptions {
+export interface FormatOptions {
     indent: number;
     trailingNewline: boolean;
 }
 
-const isNode: boolean = typeof process !== "undefined" && process.versions != null && process.versions.node != null;
-
-const formatDockerfile = async (fileName: string, options: FormatOptions) => {
-    if (!isNode) {
-        throw new Error('formatDockerfile is only supported in Node.js');
-    }
-    const fs = require('node:fs/promises');
-
-    // This would only work in Node.js, so we don't add a wasmDownload function
-    const fileBuffer = await fs.readFile(fileName);
-    const fileContents = fileBuffer.toString();
-    return formatDockerfileContents(fileContents, options);
-}
-
-const getWasmModule = () => {
-    if (isNode) {
-        const path = require('node:path');
-        const url = require('node:url');
-        const fs = require('node:fs/promises');
-        return fs.readFile(path.resolve(path.dirname(url.fileURLToPath(import.meta.url)), 'format.wasm'));
-    }
-    // In the browser, we need to fetch the wasm module
-    throw new Error('WASM module not found. Please provide a function to fetch the WASM module.');
-}
-
-const formatDockerfileContents = async (fileContents: string, options: FormatOptions, getWasm: () => Promise<Buffer> = getWasmModule) => {
+export const formatDockerfileContents = async (fileContents: string, options: FormatOptions, getWasm: () => Promise<Buffer>) => {
     const go = new Go()  // Defined in wasm_exec.js
     const encoder = new TextEncoder()
     const decoder = new TextDecoder()
@@ -77,4 +52,6 @@ const formatDockerfileContents = async (fileContents: string, options: FormatOpt
     return result
 }
 
-export { formatDockerfile, formatDockerfileContents, FormatOptions }
+export const formatDockerfile = () => {
+    throw new Error('`formatDockerfile` is not implemented in the browser. Use `formatDockerfileContents` instead.');
+}

--- a/js/node.ts
+++ b/js/node.ts
@@ -1,0 +1,22 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { formatDockerfileContents as formatDockerfileContents_, FormatOptions } from "./format.js";
+
+const getWasm = () => {
+  return fs.readFile(path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'format.wasm'));
+}
+
+export const formatDockerfileContents = async (fileContents: string, options: FormatOptions) => {
+  return formatDockerfileContents_(fileContents, options, getWasm);
+}
+
+export const formatDockerfile = async (fileName: string, options: FormatOptions) => {
+  // This would only work in Node.js, so we don't add a wasmDownload function
+  const fileBuffer = await fs.readFile(fileName);
+  const fileContents = fileBuffer.toString();
+  return formatDockerfileContents(fileContents, options);
+}
+
+export { FormatOptions }

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "dockerfmt",
-  "version": "0-2.0",
+  "name": "@reteps/dockerfmt",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "dockerfmt",
-      "version": "0-2.0",
-      "license": "ISC",
+      "name": "@reteps/dockerfmt",
+      "version": "0.2.4",
+      "license": "MIT",
       "dependencies": {
         "typescript": "^5.8.3"
       },

--- a/js/package.json
+++ b/js/package.json
@@ -12,8 +12,19 @@
   "files": [
     "dist"
   ],
-  "main": "dist/format.js",
-  "types": "dist/format.d.ts",
+  "browser": "dist/format.js",
+  "main": "dist/node.js",
+  "types": "dist/node.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/node.d.ts",
+      "browser": "./dist/format.js",
+      "default": "./dist/node.js"
+    },
+    "./format.wam": "./dist/format.wasm",
+    "./wasm_exec": "./dist/wasm_exec.js",
+    "./wasm_exec.js": "./dist/wasm_exec.js"
+  },
   "author": "Peter Stenger <pete@stenger.io>",
   "repository": "git+https://github.com/reteps/dockerfmt/tree/main/js",
   "license": "MIT",

--- a/js/wasm_exec.js
+++ b/js/wasm_exec.js
@@ -529,26 +529,4 @@
 			};
 		}
 	}
-
-	if (
-		global.require &&
-		global.require.main === module &&
-		global.process &&
-		global.process.versions &&
-		!global.process.versions.electron
-	) {
-		if (process.argv.length != 3) {
-			console.error("usage: go_js_wasm_exec [wasm binary] [arguments]");
-			process.exit(1);
-		}
-
-		const go = new Go();
-		WebAssembly.instantiate(fs.readFileSync(process.argv[2]), go.importObject).then(async (result) => {
-			let exitCode = await go.run(result.instance);
-			process.exit(exitCode);
-		}).catch((err) => {
-			console.error(err);
-			process.exit(1);
-		});
-	}
 })();


### PR DESCRIPTION
cc @reteps 