### PR TITLE
Remove types fields from package.json

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -7,10 +7,8 @@
   "author": "Peter Stenger <pete@stenger.io>",
   "license": "MIT",
   "main": "dist/node.js",
-  "types": "dist/node.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/node.d.ts",
       "browser": "./dist/format.js",
       "default": "./dist/node.js"
     },
@@ -32,8 +30,8 @@
   },
   "devDependencies": {
     "@types/node": "^22.14.0",
-    "typescript": "^5.8.3",
     "prettier": "^3.5.3",
-    "prettier-plugin-pkg": "^0.19.0"
+    "prettier-plugin-pkg": "^0.19.0",
+    "typescript": "^5.8.3"
   }
 }


### PR DESCRIPTION
TypeScript knows to look for a `.d.ts` file adjacent to whatever source file is imported; it also understand `exports` and friends. It's best practice to let TypeScript figure out which types it should use.