### PR TITLE
fix: add missing --indent parameter to pre-commit action

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,6 +6,7 @@
   args:
     - --write
     - --newline
+    - --indent
   description: Format Dockerfile files
   entry: dockerfmt
   files: ^.*Dockerfile.*$

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -14,6 +14,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number of dockerfmt",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("dockerfmt 0.2.6")
+		fmt.Println("dockerfmt 0.2.7")
 	},
 }

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reteps/dockerfmt",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "description": "",
   "repository": "git+https://github.com/reteps/dockerfmt/tree/main/js",


### PR DESCRIPTION
the pre-commit-hooks file was also missing in the newest release.