### PR TITLE
feat: support dockerfile from stdin

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -19,44 +20,79 @@ var (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "dockerfmt [Dockerfile]",
+	Use:   "dockerfmt [Dockerfile...]",
 	Short: "dockerfmt is a Dockerfile and RUN step formatter.",
 	Long:  `A updated version of the dockfmt. Uses the dockerfile parser from moby/buildkit and the shell formatter from mvdan/sh.`,
 	Run:   Run,
-	Args:  cobra.MinimumNArgs(1),
+	Args:  cobra.ArbitraryArgs,
 }
 
 func Run(cmd *cobra.Command, args []string) {
-	for _, fileName := range args {
-		originalLines, err := lib.GetFileLines(fileName)
-		if err != nil {
-			log.Fatalf("Failed to read file %s: %v", fileName, err)
-		}
-		c := &lib.Config{
-			IndentSize:      indentSize,
-			TrailingNewline: newlineFlag,
-			SpaceRedirects:  spaceRedirects,
-		}
-		formattedLines := lib.FormatFileLines(originalLines, c)
+	config := &lib.Config{
+		IndentSize:      indentSize,
+		TrailingNewline: newlineFlag,
+		SpaceRedirects:  spaceRedirects,
+	}
 
-		if checkFlag {
-			// Check if the file is already formatted
-			originalContent := strings.Join(originalLines, "")
-			if originalContent != formattedLines {
-				fmt.Printf("File %s is not formatted\n", fileName)
-				os.Exit(1)
-			}
-		} else if writeFlag {
-			// Write the formatted output back to the file
-			err := os.WriteFile(fileName, []byte(formattedLines), 0644)
+	allFormatted := true
+
+	if len(args) == 0 {
+		if writeFlag {
+			log.Fatal("Error: Cannot use -w/--write flag when reading from stdin")
+		}
+
+		inputBytes, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			log.Fatalf("Failed to read from stdin: %v", err)
+		}
+
+		if !processInput("stdin", inputBytes, config) {
+			allFormatted = false // Mark as not formatted if check fails
+		}
+
+	} else {
+		for _, fileName := range args {
+			inputBytes, err := os.ReadFile(fileName)
 			if err != nil {
-				log.Fatalf("Failed to write to file %s: %v", fileName, err)
+				log.Fatalf("Failed to read file %s: %v", fileName, err)
 			}
-		} else {
-			// Print the formatted output to stdout
-			fmt.Printf("%s", formattedLines)
+
+			if !processInput(fileName, inputBytes, config) {
+				allFormatted = false
+			}
 		}
 	}
+
+	// If check mode was enabled and any input was not formatted, exit with status 1
+	if checkFlag && !allFormatted {
+		os.Exit(1)
+	}
+}
+
+func processInput(inputName string, inputBytes []byte, config *lib.Config) (formatted bool) {
+	originalContent := string(inputBytes)
+	lines := strings.SplitAfter(strings.TrimSuffix(originalContent, "\n"), "\n")
+
+	formattedContent := lib.FormatFileLines(lines, config)
+
+	if checkFlag {
+		if originalContent != formattedContent {
+			fmt.Printf("%s is not formatted\n", inputName)
+			return false
+		}
+		return true
+	} else if writeFlag {
+		err := os.WriteFile(inputName, []byte(formattedContent), 0644)
+		if err != nil {
+			log.Fatalf("Failed to write to file %s: %v", inputName, err)
+		}
+	} else {
+		_, err := os.Stdout.Write([]byte(formattedContent))
+		if err != nil {
+			log.Fatalf("Failed to write to stdout: %v", err)
+		}
+	}
+	return true
 }
 
 func init() {

--- a/dockerfmt_test.go
+++ b/dockerfmt_test.go
@@ -45,7 +45,6 @@ func TestFormatter(t *testing.T) {
 			}
 			// Compare outLines with formattedLines
 			assert.Equal(t, strings.Join(outLines, ""), formattedLines, "Files should be equal")
-
 		})
 	}
 }


### PR DESCRIPTION
Support read dockerfile from stdin. Some editors, such as helix editor, require formatter to read from stdin and write to stdout.