### PR TITLE
Fix missing --indent value in pre-commit config

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,7 +6,7 @@
   args:
     - --write
     - --newline
-    - --indent
+    - --indent=4
     - --space-redirects
   description: Format Dockerfile files
   entry: dockerfmt


### PR DESCRIPTION
Went with 4, since thats the default