### PR TITLE
ci(pre-commit): match dockerfiles, exclude dockerignore

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -16,6 +16,6 @@
   name: dockerfmt
   pass_filenames: true
   require_serial: false
+  exclude: ".dockerignore$"
   types_or:
-    - file
-    - text
+    - dockerfile


### PR DESCRIPTION
[`Dockerfile`](https://github.com/pre-commit/identify/blob/1a3399b87beba789ab56ab395737a9b7453ad58f/identify/extensions.py#L379) is more idiomatic than `text`.

`.dockerignore` are false positives.