### PR TITLE
Add missing arg to sample setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ repos:
         args:
           # optional: add additional arguments here
           - --indent=4
+          - --write
 ```
 
 ## Limitations


### PR DESCRIPTION
Fixes #30 

I chose to add `--write`, not `--check` because check doesn't give any information about what is wrong with the file and what should be fixed:

```
dockerfmt................................................................Failed
- hook id: dockerfmt
- exit code: 1

Dockerfile is not formatted
dev.Dockerfile is not formatted
```