### PR TITLE
fix: bump version to 0.3.8

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -14,6 +14,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number of dockerfmt",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("dockerfmt 0.3.7")
+		fmt.Println("dockerfmt 0.3.8")
 	},
 }


### PR DESCRIPTION
bump version to 0.3.8

- https://github.com/Homebrew/homebrew-core/pull/246970