### PR TITLE
Add support for OCI file name 'Containerfile'

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -10,7 +10,7 @@
     - --space-redirects
   description: Format Dockerfile files
   entry: dockerfmt
-  files: ^.*Dockerfile.*$
+  files: ^.*(Container|Docker)file.*$
   id: dockerfmt
   language: golang
   name: dockerfmt


### PR DESCRIPTION
The name `Containerfile` is defined by the Open Container Initiative, which is supported by Docker but also tools like Podman and other container tools.