### PR TITLE
Make `--write` only write on change

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,9 +87,11 @@ func processInput(inputName string, inputBytes []byte, config *lib.Config) (form
 		}
 		return true
 	} else if writeFlag {
-		err := os.WriteFile(inputName, []byte(formattedContent), 0644)
-		if err != nil {
-			log.Fatalf("Failed to write to file %s: %v", inputName, err)
+		if originalContent != formattedContent {
+			err := os.WriteFile(inputName, []byte(formattedContent), 0644)
+			if err != nil {
+				log.Fatalf("Failed to write to file %s: %v", inputName, err)
+			}
 		}
 	} else {
 		_, err := os.Stdout.Write([]byte(formattedContent))


### PR DESCRIPTION
Currently, even if there are no changes `--write` will still write to file, changing its last modified timestamp. This causes a problem for things that monitors file modification by that timestamp.

For example treefmt `--fail-on-change` will fail, since it expects formatters to not write to file if nothing changes: https://github.com/numtide/treefmt/blob/main/docs/site/reference/formatter-spec.md#2-write-to-changed-files

This commit changes the behavior to only write if there are changes.