### PR TITLE
fix: preserve blank line after ONBUILD <directive>

### DIFF
--- a/lib/format.go
+++ b/lib/format.go
@@ -201,6 +201,12 @@ func FormatOnBuild(n *ExtendedNode, c *Config) string {
 	if len(n.Node.Next.Children) == 1 {
 		output, ok := FormatNode(n.Next.Children[0], c)
 		if ok {
+			// Inner directives nested under ONBUILD have StartLine=0, so their
+			// OriginalMultiline is empty and formatters that fall back to n.Original
+			// (which has no trailing newline) produce output without one.
+			if !strings.HasSuffix(output, "\n") {
+				output += "\n"
+			}
 			return n.directive() + " " + output
 		}
 	}

--- a/tests/in/onbuild-blank-lines.dockerfile
+++ b/tests/in/onbuild-blank-lines.dockerfile
@@ -1,0 +1,11 @@
+FROM alpine
+
+ONBUILD ARG FOO=bar
+
+RUN echo $FOO
+
+ONBUILD ENV BAR=baz
+
+ONBUILD LABEL foo=bar
+
+RUN echo done

--- a/tests/out/onbuild-blank-lines.dockerfile
+++ b/tests/out/onbuild-blank-lines.dockerfile
@@ -1,0 +1,11 @@
+FROM alpine
+
+ONBUILD ARG FOO=bar
+
+RUN echo $FOO
+
+ONBUILD ENV BAR=baz
+
+ONBUILD LABEL foo=bar
+
+RUN echo done


### PR DESCRIPTION
## Summary

Fixes #52.

Inner directives nested under `ONBUILD` are parsed by buildkit with `StartLine=0`/`EndLine=0`, so their `OriginalMultiline` is empty. Formatters like `formatBasic` (ARG, LABEL, USER, …) and `formatEnv` fall back to `n.Original`, which has no trailing newline. As a result, `FormatOnBuild` returned e.g. `"ONBUILD ARG FOO=bar"` with no trailing `\n`, and the subsequent blank line + directive collapsed onto the following line.

The fix appends a trailing newline in `FormatOnBuild` when the formatted inner directive lacks one, which is the invariant every other directive formatter already provides.

## Test plan

- [x] New fixture `tests/in/onbuild-blank-lines.dockerfile` / `tests/out/onbuild-blank-lines.dockerfile` covering ONBUILD ARG / ENV / LABEL with blank lines around them
- [x] `go test ./...` passes
- [x] Manually verified the formatter is now idempotent on the repro case from the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)