### PR TITLE
feat: release multiarch container images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,7 @@ jobs:
             --image-label "org.opencontainers.image.source=https://github.com/${{ github.repository }}"
         env:
           GOFLAGS: -ldflags=-X=github.com/reteps/dockerfmt/cmd.Version=${{ github.ref_name }}
+          KO_DEFAULTPLATFORMS: linux/amd64,linux/arm64
   releases-matrix:
     name: Release Go Binary
     runs-on: ubuntu-latest


### PR DESCRIPTION
Limit architectures to those shipped as release binaries for now (that is, amd64 and arm64).